### PR TITLE
bug in logic of expression

### DIFF
--- a/src/UserService.Business/Commands/User/EditUserCommand.cs
+++ b/src/UserService.Business/Commands/User/EditUserCommand.cs
@@ -91,8 +91,8 @@ namespace LT.DigitalOffice.UserService.Business
         public OperationResultResponse<bool> Execute(Guid userId, JsonPatchDocument<EditUserRequest> patch)
         {
             if (userId != _httpContext.GetUserId()
-                             && (!_accessValidator.IsAdmin()
-                             || !_accessValidator.HasRights(Kernel.Constants.Rights.AddEditRemoveUsers)))
+                             && !_accessValidator.IsAdmin()
+                             && !_accessValidator.HasRights(Kernel.Constants.Rights.AddEditRemoveUsers))
             {
                 throw new ForbiddenException("Not enough rights.");
             }

--- a/test/UserService.Business.UnitTests/EditUserCommandTests.cs
+++ b/test/UserService.Business.UnitTests/EditUserCommandTests.cs
@@ -162,6 +162,8 @@ namespace LT.DigitalOffice.UserService.Business.UnitTests
                 .Setup(x => x.IsAdmin(null))
                 .Returns(false);
 
+            ClientRequestUp(Guid.NewGuid());
+            
             Assert.AreEqual(_command.Execute(_userId, _request).Status, OperationResultStatusType.FullSuccess);
             _userRepositoryMock.Verify(repository =>
                 repository.EditUser(It.IsAny<Guid>(), It.IsAny<JsonPatchDocument<DbUser>>()), Times.Once);
@@ -174,6 +176,8 @@ namespace LT.DigitalOffice.UserService.Business.UnitTests
                 .Setup(x => x.HasRights(It.IsAny<int>()))
                 .Returns(false);
 
+            ClientRequestUp(Guid.NewGuid());
+            
             Assert.AreEqual(_command.Execute(_userId, _request).Status, OperationResultStatusType.FullSuccess);
             _userRepositoryMock.Verify(repository =>
                 repository.EditUser(It.IsAny<Guid>(), It.IsAny<JsonPatchDocument<DbUser>>()), Times.Once);


### PR DESCRIPTION
Before that expression was incorrect, and forbidden was thrown when user _is not_ in **hhtpContext**, _is not_ **admin**, but _has_ **rights**